### PR TITLE
Missing icons for superadmin

### DIFF
--- a/font.json
+++ b/font.json
@@ -343,6 +343,69 @@
       ],
       "name": "repeat",
       "file": "awesome_repeat"
+    },
+    {
+      "unicode": [
+        "\uf13a"
+      ],
+      "name": "chevron_circle_down",
+      "file": "awesome_chevron_sign_down"
+    },
+    {
+      "unicode": [
+        "\uf137"
+      ],
+      "name": "chevron_circle_left",
+      "file": "awesome_chevron_sign_left"
+    },
+    {
+      "unicode": [
+        "\uf138"
+      ],
+      "name": "chevron_circle_right",
+      "file": "awesome_chevron_sign_right"
+    },
+    {
+      "unicode": [
+        "\uf139"
+      ],
+      "name": "chevron_circle_up",
+      "file": "awesome_chevron_sign_up"
+    },
+    {
+      "unicode": [
+        "\uf24d"
+      ],
+      "name": "clone",
+      "file": "awesome_553"
+    },
+    {
+      "unicode": [
+        "\uf073"
+      ],
+      "name": "calendar",
+      "file": "awesome_calendar"
+    },
+    {
+      "unicode": [
+        "\uf10c"
+      ],
+      "name": "circle_empty",
+      "file": "awesome_circle_blank"
+    },
+    {
+      "unicode": [
+        "\uf06a"
+      ],
+      "name": "warning_sign_circle",
+      "file": "awesome_exclamation_sign"
+    },
+    {
+      "unicode": [
+        "\uf119"
+      ],
+      "name": "frown",
+      "file": "awesome_frown"
     }
   ]
 }

--- a/font.json
+++ b/font.json
@@ -185,7 +185,7 @@
     },
     {
       "unicode": [
-        "\uE001\uE008"
+        "\u03BB"
       ],
       "name": "lambda",
       "file": "lambda"


### PR DESCRIPTION
Please check if you are OK with new lambda unicode. It took it from this list: http://www.fileformat.info/info/unicode/char/3bb/index.htm

I use this tool http://bluejamesbond.github.io/CharacterMap/ for checking output font and it was not showing correct unicode for lambda. 